### PR TITLE
CustomDate issue fixed

### DIFF
--- a/Sources/QuickbooksDecoder/CustomDate.swift
+++ b/Sources/QuickbooksDecoder/CustomDate.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 
+open class QuickooksCustomDateDecoder: QuickbooksYearToDateDecoder { //=> We don't need seperate class unless there is different structure of JSON data
+
+}
+/*
 open class QuickooksCustomDateDecoder {
     
     public static func decodeCashAccounts(with:Data) -> Array<QuickbooksAccountOuput> {
@@ -296,3 +300,4 @@ open class QuickooksCustomDateDecoder {
      
 }
 
+*/

--- a/Sources/QuickbooksDecoder/YearToDate.swift
+++ b/Sources/QuickbooksDecoder/YearToDate.swift
@@ -109,7 +109,8 @@ open class QuickbooksYearToDateDecoder {
     struct BalanceSheetHeader: Codable {
         let reportName: String
         let option: [Option]
-        let dateMacro, reportBasis, startPeriod, currency: String
+        let dateMacro: String? /* Becuase this one is missing in the custom date JSON. So, We've to make it optional.*/
+        let reportBasis, startPeriod, currency: String
         let endPeriod: String
         let time: String
         let summarizeColumnsBy: String

--- a/Tests/QuickbooksDecoderTests/QuickbooksDecoderTests.swift
+++ b/Tests/QuickbooksDecoderTests/QuickbooksDecoderTests.swift
@@ -25,7 +25,7 @@ final class QuickbooksDecoderTests: XCTestCase {
         let accounts = QuickooksCustomDateDecoder.decodeCashAccounts(with: data)
         
         XCTAssertEqual(accounts.count, 3)
-        let expected = ["Account Balance", "2279.35", "51.41"]
+        let expected = ["Account Balance", "2279.35", "51.40"] //=> Not 51.41 It's 51.40 in JSON data
         
         for (key, value) in accounts.enumerated() {
             print ("\(value.name), \(value.ID), \(value.balance) ")


### PR DESCRIPTION
In the response,

1. Year to Date Response has KVP `DateMacro` but custom date doesn't has this kvp. So, we've to make it as optional variable.
2. In the test case `testCustomDate()` constant array`expected` last element is `51.41` but in the response value is `51.40`